### PR TITLE
adding ability to enable/disable assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Authorize a key for public key authentication using SSH.
 | keytype   | `'ssh-rsa'`       | SSH key type.                            |
 | comment   | *definition name* | SSH key comment.                         |
 | options   | `nil`             | SSH key options as a hash.               |
+| validate_key | true           | Enable/Disable assert_key                |
 
 Usage Examples
 ==============

--- a/definitions/ssh_authorize_key.rb
+++ b/definitions/ssh_authorize_key.rb
@@ -33,7 +33,10 @@ define :ssh_authorize_key do
     keytype: params[:keytype] || 'ssh-rsa',
     comment: params[:comment] || params[:name]
   }
-  assert_key(ssh_key[:key])
+
+  unless params[:validate_key] == false
+    assert_key(ssh_key[:key])
+  end
   assert_keytype(ssh_key[:keytype])
   assert_comment(ssh_key[:comment])
 

--- a/definitions/ssh_authorize_key.rb
+++ b/definitions/ssh_authorize_key.rb
@@ -34,9 +34,7 @@ define :ssh_authorize_key do
     comment: params[:comment] || params[:name]
   }
 
-  unless params[:validate_key] == false
-    assert_key(ssh_key[:key])
-  end
+  assert_key(ssh_key[:key]) unless params[:validate_key] == false
   assert_keytype(ssh_key[:keytype])
   assert_comment(ssh_key[:comment])
 


### PR DESCRIPTION
@zuazo Depending on the situation people do have much older keys to pass through. This will add validate_key param and give the ability to disable the assert_key if needed. 
