### PR TITLE
Added "unified_mode :true" to ./resources/ssh_authorized_key.rb

### DIFF
--- a/resources/ssh_authorized_key.rb
+++ b/resources/ssh_authorized_key.rb
@@ -21,6 +21,7 @@
 # limitations under the License.
 #
 
+unified_mode :true
 provides :ssh_authorize_key
 resource_name :ssh_authorize_key
 default_action :create


### PR DESCRIPTION
Deprecation warnings that must be addressed before upgrading to Chef Infra 18:

  The ssh_authorize_key resource in the ssh_authorized_keys cookbook should declare `unified_mode true` at 1 location:
    - /opt/kitchen/cache/cookbooks/ssh_authorized_keys/resources/ssh_authorized_key.rb
   See https://docs.chef.io/deprecations_unified_mode/ for further details.

### Description

Deprecation warnings that must be addressed before upgrading to Chef Infra 18:

  The ssh_authorize_key resource in the ssh_authorized_keys cookbook should declare `unified_mode true` at 1 location:
    - /opt/kitchen/cache/cookbooks/ssh_authorized_keys/resources/ssh_authorized_key.rb
   See https://docs.chef.io/deprecations_unified_mode/ for further details.

### Issues Resolved

resolve issue #18 deprecation warning
### Contribution Check List

- [ x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/ssh_authorized_keys-cookbook/blob/master/CONTRIBUTING.md).
