### PR TITLE
Corrected syntax of "unified_mode :true" to "unified_mode true"

### DIFF
--- a/resources/ssh_authorized_key.rb
+++ b/resources/ssh_authorized_key.rb
@@ -21,7 +21,7 @@
 # limitations under the License.
 #
 
-provides :ssh_authorize_key
+provides ssh_authorize_key
 resource_name :ssh_authorize_key
 default_action :create
 


### PR DESCRIPTION
### Description

Prevents deprecation warning when running cookbook

### Issues Resolved

#18 

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/ssh_authorized_keys-cookbook/blob/master/CONTRIBUTING.md).

Unable to run integration tests due to this error:
 bundle exec rake integration:vagrant
rake aborted!
NoMethodError: undefined method `desc' for Berkshelf::Shelf:Class
/usr/local/data/rod/git-repo/ssh_authorized_keys-cookbook/Rakefile:111:in `kitchen_instances'
/usr/local/data/rod/git-repo/ssh_authorized_keys-cookbook/Rakefile:127:in `run_kitchen'
/usr/local/data/rod/git-repo/ssh_authorized_keys-cookbook/Rakefile:132:in `block (2 levels) in <top (required)>'
/home/rod/.rbenv/versions/2.7.4/bin/bundle:23:in `load'
/home/rod/.rbenv/versions/2.7.4/bin/bundle:23:in `<main>'
Tasks: TOP => integration:vagrant
(See full trace by running task with --trace)

Any advice on how to resolve?


